### PR TITLE
Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,38 @@ Command: ./dnssec_inspector -fqdn=bsi.de
 ``` json
 {
     "dnssec": true,
-    "target": "bund.de",
+    "target": "bsi.de",
     "trustIsland": false,
-    "trustIslandAnchorZone": "",
     "zones": [
         {
-            "NSEC3iter": 10,
-            "fqdn": "bund.de",
+            "authoritativeNS": [
+                {
+                    "edns0": true,
+                    "name": "dns-1.dfn.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "xenon.bund.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "argon.bund.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "nuernberg.bund.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "bamberg.bund.de.",
+                    "resolver": false
+                }
+            ],
+            "fqdn": "bsi.de",
             "keycount": 2,
             "keys": [
                 {
@@ -67,7 +92,7 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                     "keyLength": 1024,
                     "trustAnchor": false,
                     "type": "ZSK",
-                    "valid": false
+                    "valid": true
                 },
                 {
                     "aComment": "COMPLIANT",
@@ -83,16 +108,45 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                 }
             ],
             "nsec3": true,
+            "nsec3iter": 10,
             "validatesAnswer": true,
             "validatesExtra": true,
             "validatesNs": true,
-            "validation": true,
-            "validationErrorAnswer": "",
-            "validationErrorExtra": "",
-            "validationErrorNs": ""
+            "validation": true
         },
         {
-            "NSEC3iter": 15,
+            "authoritativeNS": [
+                {
+                    "edns0": true,
+                    "name": "a.nic.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "l.de.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "n.de.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "f.nic.de.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "s.de.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "z.nic.de.",
+                    "resolver": false
+                }
+            ],
             "fqdn": "de",
             "keycount": 2,
             "keys": [
@@ -106,7 +160,7 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                     "keyLength": 1024,
                     "trustAnchor": false,
                     "type": "ZSK",
-                    "valid": false
+                    "valid": true
                 },
                 {
                     "aComment": "COMPLIANT",
@@ -122,18 +176,82 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                 }
             ],
             "nsec3": true,
+            "nsec3iter": 15,
             "validatesAnswer": true,
             "validatesExtra": true,
             "validatesNs": true,
-            "validation": true,
-            "validationErrorAnswer": "",
-            "validationErrorExtra": "",
-            "validationErrorNs": ""
+            "validation": true
         },
         {
-            "NSEC3iter": 0,
+            "authoritativeNS": [
+                {
+                    "edns0": true,
+                    "name": "a.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "b.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "c.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "d.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "e.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "f.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "g.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "h.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "i.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "j.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "k.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "l.root-servers.net.",
+                    "resolver": false
+                },
+                {
+                    "edns0": true,
+                    "name": "m.root-servers.net.",
+                    "resolver": false
+                }
+            ],
             "fqdn": ".",
-            "keycount": 3,
+            "keycount": 2,
             "keys": [
                 {
                     "aComment": "COMPLIANT",
@@ -145,19 +263,7 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                     "keyLength": 2048,
                     "trustAnchor": false,
                     "type": "ZSK",
-                    "valid": false
-                },
-                {
-                    "aComment": "COMPLIANT",
-                    "aUntil": "2022",
-                    "alg": "RSA",
-                    "hComment": "COMPLIANT",
-                    "hUntil": "prognosis impossible (2023+)",
-                    "hash": "SHA-256",
-                    "keyLength": 2048,
-                    "trustAnchor": true,
-                    "type": "KSK",
-                    "valid": false
+                    "valid": true
                 },
                 {
                     "aComment": "COMPLIANT",
@@ -173,16 +279,15 @@ Command: ./dnssec_inspector -fqdn=bsi.de
                 }
             ],
             "nsec3": false,
+            "nsec3iter": 0,
             "validatesAnswer": true,
             "validatesExtra": true,
             "validatesNs": true,
-            "validation": true,
-            "validationErrorAnswer": "",
-            "validationErrorExtra": "",
-            "validationErrorNs": ""
+            "validation": true
         }
     ]
 }
+
 ```
 
 ## Further TODOs?

--- a/README.md
+++ b/README.md
@@ -290,6 +290,11 @@ Command: ./dnssec_inspector -fqdn=bsi.de
 
 ```
 
+## Caching
+* To speed up consecutive queries we implemented a simple file based caching.
+* To use the caching functionality just set the cache flag to an empty directory.
+* It will reuses query results which are not older than a hour.
+
 ## Further TODOs?
 
 * TSIG

--- a/checkKeys.go
+++ b/checkKeys.go
@@ -75,14 +75,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "MD5"
 			k.HComment = "NON-COMPLIANT"
-			k.HUntil = "09.2004"
+			k.HUntil = "2004"
 		case "3": // DSA/SHA-1
 			k.Alg = "DSA"
 			_, _, _, _, k.KeyLength = parseDSA(x[7])
@@ -91,14 +91,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-1"
 			k.HComment = "NON-COMPLIANT"
-			k.HUntil = "10.2015"
+			k.HUntil = "2015"
 		case "5": // RSA/SHA-1
 			k.Alg = "RSA"
 			_, _, k.KeyLength = parseRSA(x[7])
@@ -107,14 +107,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-1"
 			k.HComment = "NON-COMPLIANT"
-			k.HUntil = "10.2015"
+			k.HUntil = "2015"
 		case "6": // DSA/SHA-1/NSEC3
 			k.Alg = "DSA"
 			_, _, _, _, k.KeyLength = parseDSA(x[7])
@@ -123,14 +123,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-1"
 			k.HComment = "NON-COMPLIANT"
-			k.HUntil = "10.2015"
+			k.HUntil = "2015"
 		case "7": // RSA/SHA-1/NSEC3
 			k.Alg = "RSA"
 			_, _, k.KeyLength = parseRSA(x[7])
@@ -139,14 +139,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-1"
 			k.HComment = "NON-COMPLIANT"
-			k.HUntil = "10.2015"
+			k.HUntil = "2015"
 		case "8": // RSA/SHA-256
 			k.Alg = "RSA"
 			_, _, k.KeyLength = parseRSA(x[7])
@@ -155,14 +155,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-256"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		case "10": // RSA/SHA-512
 			k.Alg = "RSA"
 			_, _, k.KeyLength = parseRSA(x[7])
@@ -171,14 +171,14 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 				k.AUntil = "2022"
 			} else if k.KeyLength >= 3072 {
 				k.AComment = "COMPLIANT"
-				k.AUntil = "prognosis impossible (2023+)"
+				k.AUntil = "9999"
 			} else {
 				k.AComment = "NON-COMPLIANT"
-				//k.AUntil = ""
+				k.AUntil = "0000"
 			}
 			k.Hash = "SHA-256"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		case "13": // ECDSA P-256 with SHA-256
 			k.Alg = "ECDSA P-256"
 			k.KeyLength = 256
@@ -186,31 +186,31 @@ func checkKey(keyRR dns.DNSKEY, k *Key) {
 			k.AUntil = "2022"
 			k.Hash = "SHA-256"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		case "14": // ECDSA P-384 with SHA-384
 			k.Alg = "ECDSA P-384"
 			k.KeyLength = 384
 			k.AComment = "COMPLIANT"
-			k.AUntil = "prognosis impossible (2023+)"
+			k.AUntil = "9999"
 			k.Hash = "SHA-384"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		case "15": // ED25519 (128bit sec)
 			k.Alg = "Ed25519"
 			k.KeyLength = 256
 			k.AComment = "COMPLIANT"
-			k.AUntil = "prognosis impossible (2023+)"
+			k.AUntil = "9999"
 			k.Hash = "SHA-512"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		case "16": // ED448
 			k.Alg = "Ed25519"
 			k.KeyLength = 488
 			k.AComment = "COMPLIANT"
-			k.AUntil = "prognosis impossible (2023+)"
+			k.AUntil = "9999"
 			k.Hash = "SHAKE-256"
 			k.HComment = "COMPLIANT"
-			k.HUntil = "prognosis impossible (2023+)"
+			k.HUntil = "9999"
 		default:
 		}
 	}

--- a/checkPath.go
+++ b/checkPath.go
@@ -91,7 +91,7 @@ corresponding KSK (key signing key). It also checks the time boundaries of the
 key signature.
 */
 func checkZSKverifiability(fqdn string) bool {
-	m := directDnssecQuery(fqdn, dns.TypeRRSIG, "")
+	m := dnssecQuery(fqdn, dns.TypeRRSIG, "AuthNS")
 	for _, r := range m.Answer {
 		if r.(*dns.RRSIG).TypeCovered == dns.TypeDNSKEY {
 			if !r.(*dns.RRSIG).ValidityPeriod(time.Now().UTC()) {
@@ -203,7 +203,7 @@ func getRRsigs(m dns.Msg, t uint16) (ret []*dns.RRSIG) {
 
 // Checks if the authServer supports EDNS0 extension by checking the additional OPT-RR (meta-RR)
 func (n *Nameserver) checkEDNS0(target string) {
-	m := directDnssecQuery(target, dns.TypeANY, n.Name)
+	m := dnssecQuery(target, dns.TypeANY, n.Name)
 	n.EDNS0 = false
 	if m.IsEdns0() != nil {
 		n.EDNS0 = true

--- a/checkPath.go
+++ b/checkPath.go
@@ -201,7 +201,7 @@ func getRRsigs(m dns.Msg, t uint16) (ret []*dns.RRSIG) {
 	return
 }
 
-// Checks if the authServer supports EDNS0 extension
+// Checks if the authServer supports EDNS0 extension by checking the additional OPT-RR (meta-RR)
 func (n *Nameserver) checkEDNS0(target string) {
 	m := directDnssecQuery(target, dns.TypeANY, n.Name)
 	n.EDNS0 = false

--- a/dnssec.go
+++ b/dnssec.go
@@ -83,7 +83,7 @@ func dnssecQuery(fqdn string, rrType uint16, server string) dns.Msg {
 	var servers []string
 	cacheID := ""
 	if Cache != "" {
-		cacheID = Cache + "dns_" + fqdn + "_" + fmt.Sprint(rrType) + "_" + server
+		cacheID = Cache + "/dns_" + fqdn + "_" + fmt.Sprint(rrType) + "_" + server
 	}
 	if cacheID != "" {
 		info, err := os.Stat(cacheID)


### PR DESCRIPTION
In many use cases the program needs to do many consecutive and repeating queries.
To speed up a caching functionality has been implemented. It is a file based cache containing query results only.
It can be activated by setting the command line option --cache=<dir_ path>
